### PR TITLE
Fix/default utc now

### DIFF
--- a/ogn/aprs_parser.py
+++ b/ogn/aprs_parser.py
@@ -4,7 +4,10 @@ from .model import Beacon, AircraftBeacon, ReceiverBeacon
 from ogn.exceptions import AprsParseError
 
 
-def parse_aprs(packet, reference_date=datetime.utcnow()):
+def parse_aprs(packet, reference_date=None):
+    if reference_date is None:
+        reference_date = datetime.utcnow()
+    print(reference_date)
     if not isinstance(packet, str):
         raise TypeError("Expected packet to be str, got %s" % type(packet))
     elif packet == "":

--- a/ogn/model/beacon.py
+++ b/ogn/model/beacon.py
@@ -30,7 +30,9 @@ class Beacon(AbstractConcreteBase, Base):
     altitude = Column(Integer)
     comment = None
 
-    def parse(self, text, reference_date=datetime.utcnow()):
+    def parse(self, text, reference_date=None):
+        if reference_date is None:
+            reference_date = datetime.utcnow()
         result = re_pattern_aprs.match(text)
         if result is None:
             raise AprsParseError(text)

--- a/tests/test_aprs_parser.py
+++ b/tests/test_aprs_parser.py
@@ -1,5 +1,8 @@
 import unittest
+import unittest.mock as mock
+
 from datetime import datetime
+from time import sleep
 
 from ogn.aprs_parser import parse_aprs
 from ogn.exceptions import AprsParseError, OgnParseError
@@ -32,6 +35,19 @@ class TestStringMethods(unittest.TestCase):
         with self.assertRaises(OgnParseError):
             parse_aprs("Lachens>APRS,TCPIP*,qAC,GLIDERN2:/165334h4344.70NI00639.19E&/A=005435 v0.2.1 CPU:0.3 RAM:1764.4/21",
                        datetime(2015, 4, 10, 16, 54))
+
+    @mock.patch('ogn.aprs_parser.Beacon')
+    def test_default_reference_date(self, beacon_mock):
+        instance = beacon_mock.return_value
+        valid_aprs_string = "Lachens>APRS,TCPIP*,qAC,GLIDERN2:/165334h4344.70NI00639.19E&/A=005435 v0.2.1 CPU:0.3 RAM:1764.4/21"
+
+        parse_aprs(valid_aprs_string)
+        call_args = instance.parse.call_args
+        sleep(1)
+        parse_aprs(valid_aprs_string)
+        call_args_one_second_later = instance.parse.call_args
+
+        self.assertNotEqual(call_args, call_args_one_second_later)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Default parameters in python are evaluated only once. This caused AmbigousTimeError after a hour. This solution is taken:
http://docs.python-guide.org/en/latest/writing/gotchas/