### PR TITLE
Use os.environ to get SQLALCHEMY_DATABASE_URI and CELERY_BROKER_* var…

### DIFF
--- a/app/config/default.py
+++ b/app/config/default.py
@@ -1,6 +1,8 @@
+import os
+
 SECRET_KEY = "i-like-ogn"
 
-SQLALCHEMY_DATABASE_URI = "postgresql://postgres@localhost:5432/ogn"
+SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", "postgresql://postgres@localhost:5432/ogn")
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # Flask-Cache stuff
@@ -8,9 +10,8 @@ CACHE_TYPE = "simple"
 CACHE_DEFAULT_TIMEOUT = 300
 
 # Celery stuff
-CELERY_BROKER_URL = "redis://localhost:6379/0"
-CELERY_RESULT_BACKEND = "redis://localhost:6379/0"
-
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
 
 from celery.schedules import crontab
 from datetime import timedelta


### PR DESCRIPTION
Would you consider to merge this PR to get environ variables?
This helps deploying on instances where redis and postgres are not in the localhost
thanks